### PR TITLE
Add multi-cmgr mode

### DIFF
--- a/roles/cmgr/README.md
+++ b/roles/cmgr/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Installs the [cmgr](https://github.com/ArmyCyberInstitute/cmgr) CTF challenge manager on a host.
+Installs the [cmgr](https://github.com/picoCTF/cmgr) CTF challenge manager on a host.
 Optionally, the `cmgrd` HTTP daemon can be configured to automatically run as a service with
 specified settings.
 

--- a/roles/cmgr/README.md
+++ b/roles/cmgr/README.md
@@ -70,3 +70,59 @@ The `cmgr_artifact_dir` variable defined above is also used for the artifact ser
 | artifact_server_other_options | Additional command-line options to pass to `cmgr-artifact-server`, e.g. `--backend-opt some=value --log-level debug`. | unset |
 | artifact_server_extra_environment_vars | Extra environment variables to set for the cmgrd-artifact-server service, as a map of string to string. | `{}` |
 | artifact_server_github_url | GitHub repo to download `cmgr-artifact-server` from. Can be used to install a forked `cmgr-artifact-server` version, but the repo must have a semver-compliant tagged release for compatibility with the `artifact_server_version` option. | `https://github.com/picoCTF/cmgr-artifact-server` |
+
+### Multi mode
+
+This mode allows multiple instances of `cmgrd` (and `cmgr_artifact_server`) to run on the same host.
+This is designed to facilitate dividing a pool of challenges across multiple remote Docker Engine hosts (by running a unique set of schemas on each cmgrd / Docker Engine pair).
+
+When multi mode is enabled, the following are suffixed by instance name:
+
+- cmgrd systemd services, e.g. `cmgr_foo.service`.
+- cmgr-artifact-server systemd services, e.g. `cmgr_artifact_server_foo.service`.
+- cmgr wrapper scripts, e.g. `cmgr_foo`.
+
+Most configuration variables are shared between all instances and function as normal, with a few exceptions documented below:
+
+- `wrapper_enabled`: Always enabled. Suffixed wrapper scripts are necessary to disambiguate between cmgr instances.
+- `cmgr_db`: A suffix will be added to each instance's database file, e.g. `cmgr_foo.db`.
+- `cmgr_artifact_dir`: Subdirectories will be created for each instance.
+- `cmgr_extra_environment_vars`: Ignored. Specify per-instance using `multi_mode_config`.
+- `artifact_server_other_options`: Ignored. Specify per-instance using `multi_mode_config`.
+- `artifact_server_extra_environment_vars`: Ignored. Specify per-instance using `multi_mode_config`.
+
+Note that multi mode will only function correctly if each cmgr instance is configured to use a distinct remote Docker engine (by specifying `DOCKER_HOST`, `DOCKER_TLS_VERIFY`, and `DOCKER_CERT_PATH` in `cmgr_extra_environment_vars`).
+
+| Name | Description | Default |
+| --- | --- | --- |
+| multi_mode_enabled | Run multiple instances of `cmgrd` and `cmgr_artifact_server` based on the `multi_mode_configuration` object. | `false` |
+| multi_mode_config | Nested mapping containing per-instance configuration. See example value below. | `{}` |
+| multi_mode_include_unsuffixed | Also run the standard, unsuffixed `cmgrd` and `cmgr_artifact_server` services, even when multi mode is enabled. Can be used to convert an existing deployment to a multi-instance server. | `false` |
+
+#### Example `multi_mode_config` value
+
+```yaml
+multi_mode_config:
+  foo:
+    cmgrd_port: 4202
+    cmgr_extra_environment_vars: {
+      "DOCKER_HOST": "tcp://foo.docker.host:2376",
+      "DOCKER_TLS_VERIFY": "true",
+      "DOCKER_CERT_PATH": "/mnt/data/foo-certs",
+    }
+    artifact_server_other_options: "-o address=0.0.0.0:4203"
+    artifact_server_extra_environment_vars: {
+      "variable": "foo"
+    }
+  bar:
+    cmgrd_port: 4204
+    cmgr_extra_environment_vars: {
+      "DOCKER_HOST": "tcp://bar.docker.host:2376",
+      "DOCKER_TLS_VERIFY": "true",
+      "DOCKER_CERT_PATH": "/mnt/data/bar-certs",
+    }
+    artifact_server_other_options: "-o address=0.0.0.0:4205"
+    artifact_server_extra_environment_vars: {
+      "variable": "foo"
+    }
+```

--- a/roles/cmgr/defaults/main.yml
+++ b/roles/cmgr/defaults/main.yml
@@ -27,3 +27,7 @@ artifact_server_backend: "selfhosted"
 artifact_server_other_options: ""
 artifact_server_extra_environment_vars: {}
 artifact_server_github_url: "https://github.com/picoCTF/cmgr-artifact-server"
+
+multi_mode_enabled: no
+multi_mode_config: {}
+multi_mode_include_unsuffixed: no

--- a/roles/cmgr/handlers/main.yml
+++ b/roles/cmgr/handlers/main.yml
@@ -10,8 +10,22 @@
     state: restarted
   become: yes
 
+- name: Restart suffixed cmgrds
+  ansible.builtin.service:
+    name: cmgrd_{{ item.suffix }}
+    state: restarted
+  become: yes
+  loop: "{{ multi_mode_config | dict2items(key_name='suffix', value_name='config') }}"
+
 - name: Restart cmgr artifact server
   ansible.builtin.service:
     name: cmgr_artifact_server
     state: restarted
   become: yes
+
+- name: Restart suffixed cmgr artifact servers
+  ansible.builtin.service:
+    name: cmgr_artifact_server_{{ item.suffix }}
+    state: restarted
+  become: yes
+  loop: "{{ multi_mode_config | dict2items(key_name='suffix', value_name='config') }}"

--- a/roles/cmgr/tasks/artifact-server-service.yml
+++ b/roles/cmgr/tasks/artifact-server-service.yml
@@ -8,6 +8,14 @@
     state: directory
     mode: "0770"
 
+- name: Ensure suffixed artifact directories exist and are root-only
+  ansible.builtin.file:
+    path: "{{ cmgr_artifact_dir }}/{{ item.suffix }}"
+    state: directory
+    mode: "0770"
+  when: multi_mode_enabled | bool
+  loop: "{{ multi_mode_config | dict2items(key_name='suffix', value_name='config') }}"
+
 - name: Ensure artifact server systemd unit exists
   ansible.builtin.template:
     src: "cmgr_artifact_server.service.j2"
@@ -17,16 +25,46 @@
   register: cmgr_artifact_server_unit
   notify:
     - Reload systemd config
+  when: (not (multi_mode_enabled | bool)) or (multi_mode_include_unsuffixed | bool)
+
+- name: Ensure suffixed artifact server systemd units exist
+  ansible.builtin.template:
+    src: "cmgr_artifact_server_suffixed.service.j2"
+    dest: "{{ systemd_unit_dir }}/cmgr_artifact_server_{{ item.suffix }}.service"
+    lstrip_blocks: yes
+    force: yes
+  register: cmgr_artifact_server_{{ item.suffix }}_unit
+  notify:
+    - Reload systemd config
+  when: multi_mode_enabled | bool
+  loop: "{{ multi_mode_config | dict2items(key_name='suffix', value_name='config') }}"
 
 - name: Ensure systemd unit is enabled
   ansible.builtin.systemd:
     name: cmgr_artifact_server.service
     daemon_reload: yes
     enabled: yes
+  when: (not (multi_mode_enabled | bool)) or (multi_mode_include_unsuffixed | bool)
+
+- name: Ensure suffixed systemd units are enabled
+  ansible.builtin.systemd:
+    name: cmgr_artifact_server_{{ item.suffix }}.service
+    daemon_reload: yes
+    enabled: yes
+  when: multi_mode_enabled | bool
+  loop: "{{ multi_mode_config | dict2items(key_name='suffix', value_name='config') }}"
 
 - name: Determine whether to restart cmgr artifact server
   ansible.builtin.assert: { that: true, quiet: true }
   changed_when: true
   notify:
     - Restart cmgr artifact server
-  when: artifact_server_installation_required or cmgr_artifact_server_unit.changed
+  when: artifact_server_installation_required or cmgr_artifact_server_unit.changed and ((not (multi_mode_enabled | bool)) or (multi_mode_include_unsuffixed | bool))
+
+- name: Determine whether to restart suffixed cmgr artifact server services
+  ansible.builtin.assert: { that: true, quiet: true }
+  changed_when: true
+  notify:
+    - Restart suffixed cmgr artifact servers
+  when: artifact_server_installation_required or cmgr_artifact_server{{ item.suffix }}_unit.changed and (multi_mode_enabled | bool)
+  loop: "{{ multi_mode_config | dict2items(key_name='suffix', value_name='config') }}"

--- a/roles/cmgr/tasks/artifact-server-service.yml
+++ b/roles/cmgr/tasks/artifact-server-service.yml
@@ -59,12 +59,12 @@
   changed_when: true
   notify:
     - Restart cmgr artifact server
-  when: artifact_server_installation_required or cmgr_artifact_server_unit.changed and ((not (multi_mode_enabled | bool)) or (multi_mode_include_unsuffixed | bool))
+  when: (artifact_server_installation_required or cmgr_artifact_server_unit.changed) and ((not (multi_mode_enabled | bool)) or (multi_mode_include_unsuffixed | bool))
 
 - name: Determine whether to restart suffixed cmgr artifact server services
   ansible.builtin.assert: { that: true, quiet: true }
   changed_when: true
   notify:
     - Restart suffixed cmgr artifact servers
-  when: artifact_server_installation_required or cmgr_artifact_server_suffixed_units.changed and (multi_mode_enabled | bool)
+  when: (artifact_server_installation_required or cmgr_artifact_server_suffixed_units.changed) and (multi_mode_enabled | bool)
   loop: "{{ multi_mode_config | dict2items(key_name='suffix', value_name='config') }}"

--- a/roles/cmgr/tasks/artifact-server-service.yml
+++ b/roles/cmgr/tasks/artifact-server-service.yml
@@ -33,7 +33,7 @@
     dest: "{{ systemd_unit_dir }}/cmgr_artifact_server_{{ item.suffix }}.service"
     lstrip_blocks: yes
     force: yes
-  register: cmgr_artifact_server_{{ item.suffix }}_unit
+  register: "cmgr_artifact_server_suffixed_units"
   notify:
     - Reload systemd config
   when: multi_mode_enabled | bool
@@ -66,5 +66,5 @@
   changed_when: true
   notify:
     - Restart suffixed cmgr artifact servers
-  when: artifact_server_installation_required or cmgr_artifact_server{{ item.suffix }}_unit.changed and (multi_mode_enabled | bool)
+  when: artifact_server_installation_required or cmgr_artifact_server_suffixed_units.changed and (multi_mode_enabled | bool)
   loop: "{{ multi_mode_config | dict2items(key_name='suffix', value_name='config') }}"

--- a/roles/cmgr/tasks/clean-upgrade.yml
+++ b/roles/cmgr/tasks/clean-upgrade.yml
@@ -10,6 +10,19 @@
   failed_when: cmgrd_service is failed and not 'Could not find the requested service' in cmgrd_service.msg
   retries: 0
   until: cmgrd_service.status.ActiveState == "stopped"
+  when: (not (multi_mode_enabled | bool)) or (multi_mode_include_unsuffixed | bool)
+
+- name: Ensure suffixed cmgrd services are stopped
+  ansible.builtin.service:
+    name: "cmgrd_{{ item.suffix }}"
+    state: stopped
+  become: yes
+  register: "cmgrd_{{ item.suffix }}"
+  failed_when: cmgrd_{{ item.suffix }} is failed and not 'Could not find the requested service' in cmgrd_{{ item.suffix }}.msg
+  retries: 0
+  until: cmgrd_{{ item.suffix }}.status.ActiveState == "stopped"
+  when: multi_mode_enabled | bool
+  loop: "{{ multi_mode_config | dict2items(key_name='suffix', value_name='config') }}"
 
 - name: Ensure cmgr-artifact-server service is stopped
   ansible.builtin.service:
@@ -20,15 +33,37 @@
   failed_when: artifact_server_service is failed and not 'Could not find the requested service' in artifact_server_service.msg
   retries: 0
   until: artifact_server_service.status.ActiveState == "stopped"
+  when: (not (multi_mode_enabled | bool)) or (multi_mode_include_unsuffixed | bool)
+
+- name: Ensure suffixed cmgr-artifact-server services are stopped
+  ansible.builtin.service:
+    name: "cmgr_artifact_server_{{ item.suffix }}"
+    state: stopped
+  become: yes
+  register: "artifact_server_service_{{ item.suffix }}"
+  failed_when: artifact_server_service_{{ item.suffix }} is failed and not 'Could not find the requested service' in artifact_server_service_{{ item.suffix }}.msg
+  retries: 0
+  until: artifact_server_service_{{ item.suffix }}.status.ActiveState == "stopped"
+  when: multi_mode_enabled | bool
+  loop: "{{ multi_mode_config | dict2items(key_name='suffix', value_name='config') }}"
 
 - name: Remove existing cmgr database
   ansible.builtin.file:
     path: "{{ cmgr_db }}"
     state: absent
+  when: (not (multi_mode_enabled | bool)) or (multi_mode_include_unsuffixed | bool)
+
+- name: Remove suffixed cmgr databases
+  ansible.builtin.file:
+    path: "{{ cmgr_db | replace('cmgr.db', 'cmgr_{{ item.suffix }}.db') }}"
+    state: absent
+  when: multi_mode_enabled | bool
+  loop: "{{ multi_mode_config | dict2items(key_name='suffix', value_name='config') }}"
+
 
 - name: Remove existing artifact tarballs
   ansible.builtin.shell: /bin/rm -rf {{ cmgr_artifact_dir }}/*
-  environment: "{{ cmgr_extra_environment_vars }}"
+  # Multi mode creates subdirectories, so this command is sufficient
 
 - name: Remove existing cmgr containers and networks
   ansible.builtin.shell: |
@@ -43,7 +78,31 @@
       docker network rm $NETWORK
     done
   environment: "{{ cmgr_extra_environment_vars }}"
+  when: (not (multi_mode_enabled | bool)) or (multi_mode_include_unsuffixed | bool)
+
+- name: Remove existing cmgr containers and networks for multi mode instances
+  ansible.builtin.shell: |
+    CMGR_NETWORKS=`docker network ls --filter=name=cmgr -q`
+    for NETWORK in $CMGR_NETWORKS
+    do
+      CONTAINERS=`docker container ls --filter=network=$NETWORK -q`
+      for CONTAINER in $CONTAINERS
+      do
+        docker container rm --force $CONTAINER
+      done
+      docker network rm $NETWORK
+    done
+  environment: "{{ item.config.cmgr_extra_environment_vars }}"
+  when: multi_mode_enabled | bool
+  loop: "{{ multi_mode_config | dict2items(key_name='suffix', value_name='config') }}"
 
 - name: Prune unused Docker images
   ansible.builtin.shell: docker image prune --all --force
   environment: "{{ cmgr_extra_environment_vars }}"
+  when: (not (multi_mode_enabled | bool)) or (multi_mode_include_unsuffixed | bool)
+
+- name: Prune unused Docker images for multi mode instances
+  ansible.builtin.shell: docker image prune --all --force
+  environment: "{{ item.config.cmgr_extra_environment_vars }}"
+  when: multi_mode_enabled | bool
+  loop: "{{ multi_mode_config | dict2items(key_name='suffix', value_name='config') }}"

--- a/roles/cmgr/tasks/clean-upgrade.yml
+++ b/roles/cmgr/tasks/clean-upgrade.yml
@@ -55,7 +55,7 @@
 
 - name: Remove suffixed cmgr databases
   ansible.builtin.file:
-    path: "{{ cmgr_db | replace('cmgr.db', 'cmgr_{{ item.suffix }}.db') }}"
+    path: "{{ cmgr_db | replace('cmgr.db', 'cmgr_') }}{{ item.suffix }}.db"
     state: absent
   when: multi_mode_enabled | bool
   loop: "{{ multi_mode_config | dict2items(key_name='suffix', value_name='config') }}"

--- a/roles/cmgr/tasks/install.yml
+++ b/roles/cmgr/tasks/install.yml
@@ -4,12 +4,12 @@
 
 - name: Check whether cmgr is installed
   ansible.builtin.stat:
-    path: "{{ install_location }}/cmgr"
+    path: "{{ install_location }}/cmgr_bin"
   register: cmgr_binary
 
 - name: Determine installed cmgr version
   ansible.builtin.command:
-    cmd: "{{ install_location }}/cmgr version"
+    cmd: "{{ install_location }}/cmgr_bin version"
   when: (upgrade | bool) and cmgr_binary.stat.exists
   register: cmgr_version_output
 
@@ -87,10 +87,10 @@
     state: absent
   when: installation_required
 
-- name: Rename cmgr binary
+- name: Create _bin-suffixed copy of cmgr binary
   ansible.builtin.command:
-    cmd: mv {{ install_location }}/cmgr {{ install_location }}/cmgr_bin
-  when: installation_required and wrapper_enabled
+    cmd: cp {{ install_location }}/cmgr {{ install_location }}/cmgr_bin
+  when: installation_required
 
 - name: Add environment variable wrapper
   ansible.builtin.template:
@@ -100,3 +100,13 @@
     force: yes
     mode: "0755"
   when: wrapper_enabled
+
+- name: Add suffixed environment variable wrappers
+  ansible.builtin.template:
+    src: "cmgr_suffixed.j2"
+    dest: "{{ install_location }}/cmgr_{{ item.suffix }}"
+    lstrip_blocks: yes
+    force: yes
+    mode: "0755"
+  when: multi_mode_enabled | bool
+  loop: "{{ multi_mode_config | dict2items(key_name='suffix', value_name='config') }}"

--- a/roles/cmgr/tasks/main.yml
+++ b/roles/cmgr/tasks/main.yml
@@ -29,21 +29,3 @@
       become: yes
 
 - ansible.builtin.meta: flush_handlers
-
-- name: Ensure cmgrd service is active
-  ansible.builtin.service:
-    name: cmgrd
-    state: started
-  become: yes
-  when: cmgrd_service_enabled | bool
-  register: cmgrd_service
-  until: cmgrd_service.status.ActiveState == "active"
-
-- name: Ensure cmgr-artifact-server service is active
-  ansible.builtin.service:
-    name: cmgr_artifact_server
-    state: started
-  become: yes
-  when: artifact_server_service_enabled | bool
-  register: artifact_server_service
-  until: artifact_server_service.status.ActiveState == "active"

--- a/roles/cmgr/tasks/service.yml
+++ b/roles/cmgr/tasks/service.yml
@@ -51,12 +51,12 @@
   changed_when: true
   notify:
     - Restart cmgrd
-  when: installation_required or cmgrd_unit.changed and ((not (multi_mode_enabled | bool)) or (multi_mode_include_unsuffixed | bool))
+  when: (installation_required or cmgrd_unit.changed) and ((not (multi_mode_enabled | bool)) or (multi_mode_include_unsuffixed | bool))
 
 - name: Determine whether to restart suffixed cmgrd services
   ansible.builtin.assert: { that: true, quiet: true }
   changed_when: true
   notify:
     - Restart suffixed cmgrds
-  when: installation_required or cmgrd_suffixed_units.changed and (multi_mode_enabled | bool)
+  when: (installation_required or cmgrd_suffixed_units.changed) and (multi_mode_enabled | bool)
   loop: "{{ multi_mode_config | dict2items(key_name='suffix', value_name='config') }}"

--- a/roles/cmgr/tasks/service.yml
+++ b/roles/cmgr/tasks/service.yml
@@ -25,7 +25,7 @@
     dest: "{{ systemd_unit_dir }}/cmgrd_{{ item.suffix }}.service"
     lstrip_blocks: yes
     force: yes
-  register: cmgrd_{{ item.suffix }}_unit
+  register: "cmgrd_suffixed_units"
   notify:
     - Reload systemd config
   when: multi_mode_enabled | bool
@@ -58,5 +58,5 @@
   changed_when: true
   notify:
     - Restart suffixed cmgrds
-  when: installation_required or cmgrd_{{ item.suffix }}_unit.changed and (multi_mode_enabled | bool)
+  when: installation_required or cmgrd_suffixed_units.changed and (multi_mode_enabled | bool)
   loop: "{{ multi_mode_config | dict2items(key_name='suffix', value_name='config') }}"

--- a/roles/cmgr/tasks/service.yml
+++ b/roles/cmgr/tasks/service.yml
@@ -17,16 +17,46 @@
   register: cmgrd_unit
   notify:
     - Reload systemd config
+  when: (not (multi_mode_enabled | bool)) or (multi_mode_include_unsuffixed | bool)
+
+- name: Ensure suffixed cmgrd systemd units exist
+  ansible.builtin.template:
+    src: "cmgrd_suffixed.service.j2"
+    dest: "{{ systemd_unit_dir }}/cmgrd_{{ item.suffix }}.service"
+    lstrip_blocks: yes
+    force: yes
+  register: cmgrd_{{ item.suffix }}_unit
+  notify:
+    - Reload systemd config
+  when: multi_mode_enabled | bool
+  loop: "{{ multi_mode_config | dict2items(key_name='suffix', value_name='config') }}"
 
 - name: Ensure systemd unit is enabled
   ansible.builtin.systemd:
     name: cmgrd.service
     daemon_reload: yes
     enabled: yes
+  when: (not (multi_mode_enabled | bool)) or (multi_mode_include_unsuffixed | bool)
+
+- name: Ensure suffixed systemd units are enabled
+  ansible.builtin.systemd:
+    name: cmgrd_{{ item.suffix }}.service
+    daemon_reload: yes
+    enabled: yes
+  when: multi_mode_enabled | bool
+  loop: "{{ multi_mode_config | dict2items(key_name='suffix', value_name='config') }}"
 
 - name: Determine whether to restart the cmgrd service
   ansible.builtin.assert: { that: true, quiet: true }
   changed_when: true
   notify:
     - Restart cmgrd
-  when: installation_required or cmgrd_unit.changed
+  when: installation_required or cmgrd_unit.changed and ((not (multi_mode_enabled | bool)) or (multi_mode_include_unsuffixed | bool))
+
+- name: Determine whether to restart suffixed cmgrd services
+  ansible.builtin.assert: { that: true, quiet: true }
+  changed_when: true
+  notify:
+    - Restart suffixed cmgrds
+  when: installation_required or cmgrd_{{ item.suffix }}_unit.changed and (multi_mode_enabled | bool)
+  loop: "{{ multi_mode_config | dict2items(key_name='suffix', value_name='config') }}"

--- a/roles/cmgr/templates/cmgr_artifact_server_suffixed.service.j2
+++ b/roles/cmgr/templates/cmgr_artifact_server_suffixed.service.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=cmgr artifact server
+Documentation=https://github.com/picoCTF/cmgr-artifact-server
+ConditionArchitecture=x86-64
+ConditionPathIsDirectory={{ cmgr_artifact_dir }}/{{ item.suffix }}
+
+[Service]
+Type=exec
+Environment="CMGR_ARTIFACT_DIR={{ cmgr_artifact_dir }}/{{ item.suffix }}"
+{% for key, value in item.config.artifact_server_extra_environment_vars.items() %}
+Environment="{{ key }}={{ value }}"
+{% endfor %}
+ExecStart={{ install_location }}/cmgr-artifact-server -b {{ artifact_server_backend }} {{ item.config.artifact_server_other_options }}
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/cmgr/templates/cmgr_suffixed.j2
+++ b/roles/cmgr/templates/cmgr_suffixed.j2
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e -o pipefail
+
+export CMGR_DB={{ cmgr_db | replace('cmgr.db', 'cmgr_{{ item.suffix }}.db') }}
+export CMGR_DIR={{ cmgr_dir }}
+export CMGR_ARTIFACT_DIR={{ cmgr_artifact_dir }}/{{ item.suffix }}
+export CMGR_LOGGING={{ cmgr_logging }}
+export CMGR_INTERFACE={{ cmgr_interface }}
+{% if cmgr_registry %}
+export CMGR_REGISTRY={{ cmgr_registry }}
+{% endif %}
+{% if cmgr_registry_user %}
+export CMGR_REGISTRY_USER={{ cmgr_registry_user }}
+{% endif %}
+{% if cmgr_registry_token %}
+export CMGR_REGISTRY_TOKEN={{ cmgr_registry_token }}
+{% endif %}
+{% if cmgr_ports %}
+export CMGR_PORTS={{ cmgr_ports }}
+{% endif %}
+{% if cmgr_enable_disk_quotas %}
+export CMGR_ENABLE_DISK_QUOTAS={{ cmgr_enable_disk_quotas }}
+{% endif %}
+{% for key, value in item.config.cmgr_extra_environment_vars.items() %}
+export {{ key }}={{ value }}
+{% endfor %}
+
+{{ install_location }}/cmgr_bin "$@"

--- a/roles/cmgr/templates/cmgr_suffixed.j2
+++ b/roles/cmgr/templates/cmgr_suffixed.j2
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e -o pipefail
 
-export CMGR_DB={{ cmgr_db | replace('cmgr.db', 'cmgr_{{ item.suffix }}.db') }}
+export CMGR_DB={{ cmgr_db | replace('cmgr.db', 'cmgr_') }}{{ item.suffix }}.db
 export CMGR_DIR={{ cmgr_dir }}
 export CMGR_ARTIFACT_DIR={{ cmgr_artifact_dir }}/{{ item.suffix }}
 export CMGR_LOGGING={{ cmgr_logging }}

--- a/roles/cmgr/templates/cmgrd.service.j2
+++ b/roles/cmgr/templates/cmgrd.service.j2
@@ -1,6 +1,6 @@
 [Unit]
 Description=cmgr daemon
-Documentation=https://github.com/ArmyCyberInstitute/cmgr
+Documentation=https://github.com/picoCTF/cmgr
 Wants=docker.service
 After=docker.service
 ConditionArchitecture=x86-64

--- a/roles/cmgr/templates/cmgrd_suffixed.service.j2
+++ b/roles/cmgr/templates/cmgrd_suffixed.service.j2
@@ -9,7 +9,7 @@ ConditionPathIsDirectory={{ cmgr_dir }}
 [Service]
 Type=exec
 LimitNOFILE=49152
-Environment="CMGR_DB={{ cmgr_db | replace('cmgr.db', 'cmgr_{{ item.suffix }}.db') }}"
+Environment="CMGR_DB={{ cmgr_db | replace('cmgr.db', 'cmgr_') }}{{ item.suffix }}.db"
 Environment="CMGR_DIR={{ cmgr_dir }}"
 Environment="CMGR_ARTIFACT_DIR={{ cmgr_artifact_dir }}/{{ item.suffix }}"
 Environment="CMGR_LOGGING={{ cmgr_logging }}"

--- a/roles/cmgr/templates/cmgrd_suffixed.service.j2
+++ b/roles/cmgr/templates/cmgrd_suffixed.service.j2
@@ -1,6 +1,6 @@
 [Unit]
 Description=cmgr daemon
-Documentation=https://github.com/ArmyCyberInstitute/cmgr
+Documentation=https://github.com/picoCTF/cmgr
 Wants=docker.service
 After=docker.service
 ConditionArchitecture=x86-64

--- a/roles/cmgr/templates/cmgrd_suffixed.service.j2
+++ b/roles/cmgr/templates/cmgrd_suffixed.service.j2
@@ -1,0 +1,35 @@
+[Unit]
+Description=cmgr daemon
+Documentation=https://github.com/ArmyCyberInstitute/cmgr
+Wants=docker.service
+After=docker.service
+ConditionArchitecture=x86-64
+ConditionPathIsDirectory={{ cmgr_dir }}
+
+[Service]
+Type=exec
+LimitNOFILE=49152
+Environment="CMGR_DB={{ cmgr_db | replace('cmgr.db', 'cmgr_{{ item.suffix }}.db') }}"
+Environment="CMGR_DIR={{ cmgr_dir }}"
+Environment="CMGR_ARTIFACT_DIR={{ cmgr_artifact_dir }}/{{ item.suffix }}"
+Environment="CMGR_LOGGING={{ cmgr_logging }}"
+Environment="CMGR_INTERFACE={{ cmgr_interface }}"
+{% if cmgr_registry %}
+Environment="CMGR_REGISTRY={{ cmgr_registry }}"
+{% endif %}
+{% if cmgr_registry_user %}
+Environment="CMGR_REGISTRY_USER={{ cmgr_registry_user }}"
+{% endif %}
+{% if cmgr_registry_token %}
+Environment="CMGR_REGISTRY_TOKEN={{ cmgr_registry_token }}"
+{% endif %}
+{% if cmgr_ports %}
+Environment="CMGR_PORTS={{ cmgr_ports }}"
+{% endif %}
+{% for key, value in item.config.cmgr_extra_environment_vars.items() %}
+Environment="{{ key }}={{ value }}"
+{% endfor %}
+ExecStart={{ install_location }}/cmgrd --port {{ item.config.cmgrd_port }}
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Adds the ability to run multiple, suffixed cmgr instances on the same host. This is intended for situations where a set of challenges is distributed across multiple remote Docker Engine servers.

The cmgr instances are accessed like:

- `cmgr_<suffix>` (command-line wrapper)
- `cmgrd_<suffix>.service` (systemd unit)
- `cmgr_artifact_server_<suffix>.service` (systemd unit)

This mode is backwards-compatible with a server already running an existing unsuffixed cmgr instance using the role variable `multi_mode_include_unsuffixed: yes`.