### PR TITLE
Add `docker-reaper` service to docker role

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,8 +1,6 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-ENV['VAGRANT_EXPERIMENTAL'] = "disks"
-
 # All Vagrant configuration is done below. The "2" in Vagrant.configure
 # configures the configuration version (we support older styles for
 # backwards compatibility). Please don't change it unless you know what

--- a/roles/docker/README.md
+++ b/roles/docker/README.md
@@ -123,6 +123,10 @@ Access to the [EC2 metadata endpoint](https://docs.aws.amazon.com/AWSEC2/latest/
 
 This is [configurable](#firewall-settings), and additional IPs can be blocked if desired.
 
+## Docker resource reaper
+
+[docker-reaper](https://github.com/picoCTF/oci-interceptor) is integrated as a systemd service. By default, it will run every minute, removing any on-demand cmgr containers and networks which are more than an hour old. This can be disabled or customized via [role variables](#docker-reaper-settings).
+
 ## Role Variables
 
 ### General settings
@@ -184,3 +188,13 @@ This is [configurable](#firewall-settings), and additional IPs can be blocked if
 | Name | Description | Default |
 | --- | --- | --- |
 | `container_deny_ipv4_cidrs` | Traffic to these IPv4 CIDRs from inside any container is rejected. | `["169.254.169.254/32"]` |
+
+### docker-reaper settings
+
+| Name | Description | Default |
+| --- | --- | --- |
+| `docker_reaper_enabled` | Whether to run `docker-reaper` as a scheduled systemd service. | `yes` |
+| `docker_reaper_version` | The version of `docker-reaper` to run. | `latest` |
+| `docker_reaper_upgrade` | Whether to upgrade `docker-reaper` if already installed. | `no` |
+| `docker_reaper_command` | Command-line arguments to pass to `docker-reaper`. | `containers --filter label=cmgr.dynamic=true --min-age 60m --reap-networks` |
+| `docker_reaper_interval_secs` | How frequently (in seconds) to run the specified `docker-reaper` command. | `60` |

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -26,3 +26,9 @@ logs_max_size: "10m"
 logs_max_files: 3
 
 container_deny_ipv4_cidrs: ["169.254.169.254/32"]
+
+docker_reaper_enabled: yes
+docker_reaper_version: "latest"
+docker_reaper_upgrade: no
+docker_reaper_command: "containers --filter label=cmgr.dynamic=true --min-age 60m --reap-networks"
+docker_reaper_interval_secs: 60

--- a/roles/docker/handlers/main.yml
+++ b/roles/docker/handlers/main.yml
@@ -23,3 +23,15 @@
   community.general.ufw:
     state: reloaded
   become: yes
+
+- name: Restart docker-reaper service unit
+  ansible.builtin.service:
+    name: docker_reaper.service
+    state: restarted
+  become: yes
+
+- name: Restart docker-reaper timer unit
+  ansible.builtin.service:
+    name: docker_reaper.timer
+    state: restarted
+  become: yes

--- a/roles/docker/tasks/docker-reaper.yml
+++ b/roles/docker/tasks/docker-reaper.yml
@@ -1,0 +1,105 @@
+---
+
+# Install docker-reaper and set up systemd service
+
+- name: Check whether docker-reaper is installed
+  ansible.builtin.stat:
+    path: "{{ docker_reaper_install_path }}/docker-reaper"
+  register: docker_reaper_binary
+
+- name: Determine installed docker-reaper version
+  ansible.builtin.command:
+    cmd: echo "v`{{ docker_reaper_install_path }}/docker-reaper --version | cut -d ' ' -f 2,2`"
+  when: (docker_reaper_upgrade | bool) and docker_reaper_binary.stat.exists
+  register: docker_reaper_version_output
+
+- name: Determine latest docker-reaper version
+  ansible.builtin.uri:
+    url: "{{ docker_reaper_github_url }}/releases/latest"
+    method: HEAD
+    follow_redirects: safe
+  register: docker_reaper_latest_version_response
+  when: docker_reaper_version == "latest" and (not docker_reaper_binary.stat.exists or (docker_reaper_upgrade | bool))
+
+- name: Determine whether (re-)installation is necessary
+  ansible.builtin.set_fact:
+    docker_reaper_installation_required: "{{ (not docker_reaper_binary.stat.exists) or ((docker_reaper_upgrade | bool) and docker_reaper_version != 'latest' and docker_reaper_version_output.stdout != docker_reaper_version) or ((docker_reaper_upgrade | bool) and docker_reaper_version == 'latest' and docker_reaper_version_output.stdout != docker_reaper_latest_version_response.url.split('/tag/')[1]) }}"
+
+- name: Create temporary directory for download
+  ansible.builtin.tempfile:
+    state: directory
+  register: docker_reaper_download_dir
+  when: docker_reaper_installation_required
+
+- name: Download docker-reaper binary
+  ansible.builtin.get_url:
+    dest: "{{ docker_reaper_download_dir.path }}"
+    url: "{{ docker_reaper_github_url }}/releases/download/{{ docker_reaper_latest_version_response.url.split('/tag/')[1] if docker_reaper_version == 'latest' else docker_reaper_version }}/{{ docker_reaper_binary_filename }}"
+  when: docker_reaper_installation_required
+
+- name: Unpack docker-reaper binary
+  ansible.builtin.unarchive:
+    dest: "{{ docker_reaper_download_dir.path }}"
+    remote_src: yes
+    src: "{{ docker_reaper_download_dir.path }}/{{ docker_reaper_binary_filename }}"
+  when: docker_reaper_installation_required
+
+- name: Copy docker-reaper binary to install location
+  ansible.builtin.copy:
+    src: "{{ docker_reaper_download_dir.path }}/docker-reaper"
+    dest: "{{ docker_reaper_install_path }}"
+    mode: "0755"
+    remote_src: yes
+  when: docker_reaper_installation_required
+
+- name: Remove temporary directory
+  ansible.builtin.file:
+    path: "{{ docker_reaper_download_dir.path }}"
+    state: absent
+  when: docker_reaper_installation_required
+
+- name: Ensure docker_reaper.service systemd unit exists
+  ansible.builtin.template:
+    src: "docker_reaper.service.j2"
+    dest: "{{ systemd_unit_dir }}/docker_reaper.service"
+    lstrip_blocks: yes
+    force: yes
+  register: docker_reaper_service_unit
+  notify:
+    - Reload systemd config
+
+- name: Ensure docker_reaper.service unit is enabled
+  ansible.builtin.systemd:
+    name: docker_reaper.service
+    daemon_reload: yes
+    enabled: yes
+
+- name: Ensure docker_reaper.timer systemd unit exists
+  ansible.builtin.template:
+    src: "docker_reaper.timer.j2"
+    dest: "{{ systemd_unit_dir }}/docker_reaper.timer"
+    lstrip_blocks: yes
+    force: yes
+  register: docker_reaper_timer_unit
+  notify:
+    - Reload systemd config
+
+- name: Ensure docker_reaper.timer unit is enabled
+  ansible.builtin.systemd:
+    name: docker_reaper.timer
+    daemon_reload: yes
+    enabled: yes
+
+- name: Determine whether to restart the docker_reaper.service unit
+  ansible.builtin.assert: { that: true, quiet: true }
+  changed_when: true
+  notify:
+    - Restart docker-reaper service unit
+  when: (docker_reaper_installation_required or docker_reaper_service_unit.changed)
+
+- name: Determine whether to restart the docker_reaper.timer unit
+  ansible.builtin.assert: { that: true, quiet: true }
+  changed_when: true
+  notify:
+    - Restart docker-reaper timer unit
+  when: docker_reaper_timer_unit.changed

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -48,6 +48,12 @@
     apply:
       become: yes
 
+- include_tasks: docker-reaper.yml
+  when: docker_reaper_enabled | bool
+  args:
+    apply:
+      become: yes
+
 - ansible.builtin.meta: flush_handlers
 
 - name: Ensure Docker service is active

--- a/roles/docker/templates/docker_reaper.service.j2
+++ b/roles/docker/templates/docker_reaper.service.j2
@@ -1,0 +1,13 @@
+[Unit]
+Description=docker-reaper
+Documentation=https://github.com/picoCTF/docker-reaper
+Wants=docker.service
+After=docker.service
+ConditionArchitecture=x86-64
+
+[Service]
+Type=exec
+ExecStart={{ docker_reaper_install_path }}/docker-reaper {{ docker_reaper_command }}
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/docker/templates/docker_reaper.timer.j2
+++ b/roles/docker/templates/docker_reaper.timer.j2
@@ -1,0 +1,13 @@
+[Unit]
+Description="docker-reaper timer"
+Wants=docker.service
+After=docker.service
+ConditionArchitecture=x86-64
+
+[Timer]
+OnBootSec=60
+OnUnitActiveSec={{ docker_reaper_interval_secs }}
+Unit=docker_reaper.service
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/docker/vars/main.yml
+++ b/roles/docker/vars/main.yml
@@ -13,6 +13,7 @@ client_key_path: "{{ tls_cert_path }}/key.pem"
 client_csr_path: "{{ tls_cert_path }}/cert.csr"
 client_cert_path: "{{ tls_cert_path }}/cert.pem"
 
+systemd_unit_dir: "/etc/systemd/system/"
 systemd_docker_drop_in_dir: "/etc/systemd/system/docker.service.d"
 systemd_ufw_drop_in_dir: "/etc/systemd/system/ufw.service.d"
 
@@ -24,3 +25,7 @@ parent_cgroup_path: "/etc/systemd/system/{{ parent_cgroup }}"
 oci_interceptor_install_path: "/usr/local/bin"
 oci_interceptor_github_url: "https://github.com/picoCTF/oci-interceptor"
 oci_interceptor_binary_filename: "oci-interceptor_x86_64-unknown-linux-gnu.tar.gz"
+
+docker_reaper_install_path: "/usr/local/bin"
+docker_reaper_github_url: "https://github.com/picoCTF/docker-reaper"
+docker_reaper_binary_filename: "docker-reaper-x86_64-unknown-linux-gnu.tar.gz"


### PR DESCRIPTION
Adds `docker_reaper.service` and `docker_reaper.timer` systemd units by default when using the `docker` role.
As I want to set defaults that are useful to us, the service runs every minute and removes any containers and networks associated with on-demand cmgr challenges (i.e. with label `cmgr.dynamic=true`) which are at least 60m old. However, this can be adjusted if a different `docker-reaper` invocation is needed.