### PR TITLE
Vary docker-ce pkgname on ubuntu ver

### DIFF
--- a/roles/docker/tasks/install.yml
+++ b/roles/docker/tasks/install.yml
@@ -26,8 +26,8 @@
 - name: Ensure Docker Engine is pinned to 28.5.2 (last < 29)
   ansible.builtin.apt:
     name:
-      - docker-ce=5:28.5.2-1~ubuntu.22.04~jammy
-      - docker-ce-cli=5:28.5.2-1~ubuntu.22.04~jammy
+      - "docker-ce={{ docker_version_pin_map[ansible_distribution_release] }}"
+      - "docker-ce-cli={{ docker_version_pin_map[ansible_distribution_release] }}"
     state: present
     allow_downgrade: yes
     update_cache: yes

--- a/roles/docker/vars/main.yml
+++ b/roles/docker/vars/main.yml
@@ -29,3 +29,7 @@ oci_interceptor_binary_filename: "oci-interceptor_x86_64-unknown-linux-gnu.tar.g
 docker_reaper_install_path: "/usr/local/bin"
 docker_reaper_github_url: "https://github.com/picoCTF/docker-reaper"
 docker_reaper_binary_filename: "docker-reaper-x86_64-unknown-linux-gnu.tar.gz"
+
+docker_version_pin_map:
+  jammy: "5:28.5.2-1~ubuntu.22.04~jammy"
+  noble: "5:28.5.2-1~ubuntu.24.04~noble"


### PR DESCRIPTION
Still latest docker < 29 but given our mix of ubuntu 22 and 24, accommodates ansible run on both